### PR TITLE
Load .env before config reads API key

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 dependencies = [
     "httpx>=0.27.0",
     "pydantic>=2.0.0",
+    "python-dotenv>=1.0.0",
 ]
 keywords = [
     "ukpowernetworks",
@@ -47,7 +48,6 @@ dev = [
     "pytest-cov>=7.0.0",
     "pytest-asyncio>=1.3.0",
     "pytest-httpx>=0.36.0",
-    "python-dotenv>=1.0.0",
     "ruff>=0.15.0",
     "pre-commit>=4.5.1",
 ]
@@ -109,7 +109,6 @@ all = [
     "pytest-cov>=7.0.0",
     "pytest-asyncio>=1.3.0",
     "pytest-httpx>=0.36.0",
-    "python-dotenv>=1.0.0",
     "ruff>=0.15.0",
     "pre-commit>=4.5.1",
     "jupyter>=1.0.0",

--- a/src/ukpyn/config.py
+++ b/src/ukpyn/config.py
@@ -2,6 +2,8 @@
 
 import os
 
+from dotenv import load_dotenv
+
 # API Base URL constant
 BASE_URL: str = "https://ukpowernetworks.opendatasoft.com"
 
@@ -13,6 +15,11 @@ DEFAULT_TIMEOUT: int = 30
 
 # Environment variable name for API key
 API_KEY_ENV_VAR: str = "UKPN_API_KEY"
+
+
+def load_environment() -> None:
+    """Load variables from a local .env file into the process environment."""
+    load_dotenv()
 
 
 def check_api_key() -> None:
@@ -29,13 +36,7 @@ def check_api_key() -> None:
     Raises:
         AuthenticationError: If no API key is found.
     """
-    # Best-effort .env loading so callers don't need to do it themselves.
-    try:
-        from dotenv import load_dotenv
-
-        load_dotenv()
-    except ImportError:  # python-dotenv is optional
-        pass
+    load_environment()
 
     if not os.getenv(API_KEY_ENV_VAR):
         from .exceptions import AuthenticationError
@@ -67,6 +68,7 @@ class Config:
             base_url: Base URL for the API. Defaults to UK Power Networks OpenDataSoft URL.
             timeout: Request timeout in seconds. Defaults to 30.
         """
+        load_environment()
         self._api_key = api_key or os.getenv(API_KEY_ENV_VAR)
         self._base_url = base_url.rstrip("/")
         self._timeout = timeout

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,7 @@ from ukpyn.exceptions import AuthenticationError
 def test_config_defaults(monkeypatch) -> None:
     """Config uses package defaults when not overridden."""
     monkeypatch.delenv(API_KEY_ENV_VAR, raising=False)
+    monkeypatch.setattr("ukpyn.config.load_dotenv", lambda: None)
 
     config = Config()
 
@@ -49,6 +50,7 @@ def test_config_base_url_trailing_slash_removed() -> None:
 def test_headers_without_api_key(monkeypatch) -> None:
     """Headers omit Authorization when key is not configured."""
     monkeypatch.delenv(API_KEY_ENV_VAR, raising=False)
+    monkeypatch.setattr("ukpyn.config.load_dotenv", lambda: None)
     config = Config()
 
     headers = config.get_headers()
@@ -70,6 +72,7 @@ def test_headers_with_api_key() -> None:
 def test_empty_api_key_not_considered_configured(monkeypatch) -> None:
     """Empty API key should not be considered configured."""
     monkeypatch.delenv(API_KEY_ENV_VAR, raising=False)
+    monkeypatch.setattr("ukpyn.config.load_dotenv", lambda: None)
     config = Config(api_key="")
 
     assert config.has_api_key is False
@@ -79,7 +82,7 @@ def test_empty_api_key_not_considered_configured(monkeypatch) -> None:
 def test_check_api_key_raises_when_missing(monkeypatch) -> None:
     """check_api_key raises AuthenticationError when key is not set."""
     monkeypatch.delenv(API_KEY_ENV_VAR, raising=False)
-    monkeypatch.setattr("dotenv.load_dotenv", lambda: None)
+    monkeypatch.setattr("ukpyn.config.load_dotenv", lambda: None)
 
     with pytest.raises(AuthenticationError, match="UKPN_API_KEY"):
         check_api_key()
@@ -90,3 +93,19 @@ def test_check_api_key_passes_when_set(monkeypatch) -> None:
     monkeypatch.setenv(API_KEY_ENV_VAR, "test-key")
 
     check_api_key()  # should not raise
+
+
+def test_config_reads_api_key_from_dotenv(monkeypatch) -> None:
+    """Config loads API key from a local .env before building headers."""
+    monkeypatch.delenv(API_KEY_ENV_VAR, raising=False)
+
+    def fake_load_dotenv() -> None:
+        monkeypatch.setenv(API_KEY_ENV_VAR, "dotenv-key")
+
+    monkeypatch.setattr("ukpyn.config.load_dotenv", fake_load_dotenv)
+
+    config = Config()
+
+    assert config.api_key == "dotenv-key"
+    assert config.has_api_key is True
+    assert config.get_headers()["Authorization"] == "Apikey dotenv-key"


### PR DESCRIPTION
## Summary

Fixes API key loading when `UKPN_API_KEY` is provided via a local `.env` file.

Previously, `Config()` read `os.getenv("UKPN_API_KEY")` before `.env` was loaded. This meant simple examples could create a client without an authorization header, even though `check_api_key()` later loaded `.env`.

## Changes

- Move `python-dotenv` into runtime dependencies.
- Add `load_environment()` in `ukpyn.config`.
- Load `.env` before `Config` reads `UKPN_API_KEY`.
- Add a unit test covering `.env` loading before header construction.

## Verification

- `pytest tests/test_config.py -q --no-cov -p no:cacheprovider`
- `pytest tests/orchestrators/test_ltds.py -q --no-cov -p no:cacheprovider`
- `ruff check pyproject.toml src/ukpyn/config.py tests/test_config.py`
- Confirmed the LTDS example works with `UKPN_API_KEY` loaded from `.env`:
  `Rows returned: 100`
