### PR TITLE
feat(cli): adding fetch and list features to CLI

### DIFF
--- a/src/ukpyn/cli.py
+++ b/src/ukpyn/cli.py
@@ -3,8 +3,38 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 
-from . import __version__
+from . import UKPNClient, __version__
+
+
+def _handle_fetch(args, parser):
+    dataset = args.dataset
+    output = args.output
+    if dataset is None:
+        parser.print_help()
+        return 0
+
+    print(f"Fetching {dataset}, output: {output}")
+    return 0
+
+
+async def _handle_list(args, parser):
+    if not args.list_target:
+        parser.print_help()
+        return 0
+    if args.list_target == "datasets":
+        client = UKPNClient()
+        if args.domain:
+            print(args.domain)
+        else:
+            resp = await client.list_datasets()
+            all_datasets = [(item.dataset.dataset_id, item.dataset.metas.default['title']) for item in resp.datasets]
+            formatted_datasets_info = '\n'.join(f"{id}: {title}" for id, title in all_datasets)
+            print(formatted_datasets_info)
+    elif args.list_target == "domains":
+        print("Listing domains")
+    return 0
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -23,6 +53,24 @@ def build_parser() -> argparse.ArgumentParser:
         help="Show beginner and advanced getting-started resources",
     )
 
+    # -- Fetch --
+    fetch_parser = subparsers.add_parser("fetch", help="Fetch records from a dataset")
+
+    fetch_parser.add_argument("dataset", nargs="?", help="Name of the dataset (e.g dispatches, table_3a)")
+    fetch_parser.add_argument("--output", help="Saves the dataset to a file inferred from the extension (.csv, .json)")
+    fetch_parser.set_defaults(func=_handle_fetch, parser=fetch_parser)
+
+    # -- List --
+    list_parser = subparsers.add_parser("list", help="Lists all available datasets or domains")
+    list_subparsers = list_parser.add_subparsers(dest="list_target")
+
+    list_datasets_parser = list_subparsers.add_parser("datasets", help="Lists all available datasets")
+    list_datasets_parser.add_argument("--domain", help="Filter by domain, e.g ltds")
+
+    list_subparsers.add_parser("domains", help="Lists all available domains")
+
+    list_parser.set_defaults(func=_handle_list, parser=list_parser)
+
     return parser
 
 
@@ -34,11 +82,23 @@ def _print_quickstart() -> None:
     print("- Full docs: README.md")
 
 
+def fetch_dataset(args) -> None:
+    """
+    Fetches a specified dataset, allowing for parameters
+    to filter the given dataset and specify the output type.
+
+    By default this will present a summary of the dataset.
+    """
+    if args.dataset:
+        print(args.dataset)
+    print("Fetch datasets")
+
+
 def main(argv: list[str] | None = None) -> int:
     """Run the ukpyn CLI."""
     parser = build_parser()
     args = parser.parse_args(argv)
-
+    
     if args.command == "version":
         print(__version__)
         return 0
@@ -46,6 +106,12 @@ def main(argv: list[str] | None = None) -> int:
     if args.command in (None, "quickstart"):
         _print_quickstart()
         return 0
+
+    if hasattr(args, "func"):
+        result = args.func(args, args.parser)
+        if asyncio.iscoroutine(result):
+            return asyncio.run(result)
+        return result
 
     parser.print_help()
     return 0

--- a/src/ukpyn/cli.py
+++ b/src/ukpyn/cli.py
@@ -7,20 +7,35 @@ import asyncio
 
 from . import __version__
 from .dataset_registry import ALL_DATASETS, DOMAIN_MAP
+from . import UKPNClient
 
 
-def _handle_fetch(args, parser):
+async def _handle_fetch(args, parser):
     dataset = args.dataset
-    output = args.output
     if dataset is None:
         parser.print_help()
         return 0
 
+    if dataset not in ALL_DATASETS.values():
+        print(f"An invalid dataset was provided: {dataset}")
+        parser.print_help()
+        return 0
+
+    output = args.output.strip(".")
+    VALID_EXTENSIONS = ["csv", "json"]
+    if output not in VALID_EXTENSIONS:
+        print(f"An invalid extension was provided: {output}. Please use a valid extensions: {', '.join(VALID_EXTENSIONS)}")
+        parser.print_help()
+        return 0
+
+
     print(f"Fetching {dataset}, output: {output}")
+    client = UKPNClient()
+
     return 0
 
 
-async def _handle_list(args, parser):
+def _handle_list(args, parser):
     if not args.list_target:
         parser.print_help()
         return 0
@@ -32,7 +47,7 @@ async def _handle_list(args, parser):
             else:
                 valid_domains = ", ".join(sorted(DOMAIN_MAP.keys()))
                 print(
-                    f"Invalid domain provided: '{args.domain}'. Please use a valid domain: {valid_domains}"
+                    f"An invalid domain was provided: '{args.domain}'. Please use a valid domain: {valid_domains}"
                 )
         else:
             all_datasets = set(ALL_DATASETS.values())
@@ -67,7 +82,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     fetch_parser.add_argument(
         "--output",
-        help="Saves the dataset to a file inferred from the extension (.csv, .json)",
+        help="Saves the dataset to a file inferred from the extension (csv, json)",
     )
     fetch_parser.set_defaults(func=_handle_fetch, parser=fetch_parser)
 

--- a/src/ukpyn/cli.py
+++ b/src/ukpyn/cli.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import argparse
 import asyncio
 
-from . import __version__
+from . import EXPORT_FORMATS, UKPNClient, __version__
 from .dataset_registry import ALL_DATASETS, DOMAIN_MAP
-from . import UKPNClient
 
 
 async def _handle_fetch(args, parser):
@@ -21,18 +20,30 @@ async def _handle_fetch(args, parser):
         parser.print_help()
         return 0
 
-    output = args.output.strip(".")
-    VALID_EXTENSIONS = ["csv", "json"]
-    if output not in VALID_EXTENSIONS:
-        print(f"An invalid extension was provided: {output}. Please use a valid extensions: {', '.join(VALID_EXTENSIONS)}")
-        parser.print_help()
+    client = UKPNClient()
+    output = args.output
+    if output:
+        output = output.strip(".")
+        if output not in EXPORT_FORMATS:
+            print(f"An invalid extension was provided: {output}. Please use a valid extensions: {', '.join(EXPORT_FORMATS)}")
+            parser.print_help()
+            return 0
+
+        output_filename = f"{dataset}.{output}"
+
+        print(f"Exporting {dataset} to {output}")
+        exported_dataset = await client.export_data(dataset_id=dataset, format=output)
+
+        with open(output_filename, "wb") as output_file:
+            output_file.write(exported_dataset)
+        print(f"Successfully wrote to {output_filename}")
+
         return 0
 
 
     print(f"Fetching {dataset}, output: {output}")
-    client = UKPNClient()
-
-    return 0
+    dataset = await client.get_dataset(dataset)
+    return dataset.summary()
 
 
 def _handle_list(args, parser):

--- a/src/ukpyn/cli.py
+++ b/src/ukpyn/cli.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import argparse
 import asyncio
 
-from . import UKPNClient, __version__
+from . import __version__
+from .dataset_registry import ALL_DATASETS, DOMAIN_MAP
 
 
 def _handle_fetch(args, parser):
@@ -24,16 +25,21 @@ async def _handle_list(args, parser):
         parser.print_help()
         return 0
     if args.list_target == "datasets":
-        client = UKPNClient()
         if args.domain:
-            print(args.domain)
+            if args.domain in DOMAIN_MAP:
+                domain_filtered_datasets = DOMAIN_MAP[args.domain].values()
+                print("\n".join(sorted(domain_filtered_datasets)))
+            else:
+                valid_domains = ", ".join(sorted(DOMAIN_MAP.keys()))
+                print(
+                    f"Invalid domain provided: '{args.domain}'. Please use a valid domain: {valid_domains}"
+                )
         else:
-            resp = await client.list_datasets()
-            all_datasets = [(item.dataset.dataset_id, item.dataset.metas.default['title']) for item in resp.datasets]
-            formatted_datasets_info = '\n'.join(f"{id}: {title}" for id, title in all_datasets)
-            print(formatted_datasets_info)
+            all_datasets = set(ALL_DATASETS.values())
+            print("\n".join(sorted(all_datasets)))
     elif args.list_target == "domains":
-        print("Listing domains")
+        all_domains = DOMAIN_MAP.keys()
+        print("\n".join(sorted(all_domains)))
     return 0
 
 
@@ -56,15 +62,24 @@ def build_parser() -> argparse.ArgumentParser:
     # -- Fetch --
     fetch_parser = subparsers.add_parser("fetch", help="Fetch records from a dataset")
 
-    fetch_parser.add_argument("dataset", nargs="?", help="Name of the dataset (e.g dispatches, table_3a)")
-    fetch_parser.add_argument("--output", help="Saves the dataset to a file inferred from the extension (.csv, .json)")
+    fetch_parser.add_argument(
+        "dataset", nargs="?", help="Name of the dataset (e.g dispatches, table_3a)"
+    )
+    fetch_parser.add_argument(
+        "--output",
+        help="Saves the dataset to a file inferred from the extension (.csv, .json)",
+    )
     fetch_parser.set_defaults(func=_handle_fetch, parser=fetch_parser)
 
     # -- List --
-    list_parser = subparsers.add_parser("list", help="Lists all available datasets or domains")
+    list_parser = subparsers.add_parser(
+        "list", help="Lists all available datasets or domains"
+    )
     list_subparsers = list_parser.add_subparsers(dest="list_target")
 
-    list_datasets_parser = list_subparsers.add_parser("datasets", help="Lists all available datasets")
+    list_datasets_parser = list_subparsers.add_parser(
+        "datasets", help="Lists all available datasets"
+    )
     list_datasets_parser.add_argument("--domain", help="Filter by domain, e.g ltds")
 
     list_subparsers.add_parser("domains", help="Lists all available domains")
@@ -98,7 +113,7 @@ def main(argv: list[str] | None = None) -> int:
     """Run the ukpyn CLI."""
     parser = build_parser()
     args = parser.parse_args(argv)
-    
+
     if args.command == "version":
         print(__version__)
         return 0

--- a/src/ukpyn/dataset_registry.py
+++ b/src/ukpyn/dataset_registry.py
@@ -375,3 +375,26 @@ ALL_DATASETS: dict[str, str] = {
     **APPENDIX_G_DATASETS,
     **REFERENCE_DATASETS,
 }
+
+# =============================================================================
+# Domain mapping for filtering
+# =============================================================================
+DOMAIN_MAP: dict[str, dict[str, str]] = {
+    "ltds": LTDS_DATASETS,
+    "dfes": DFES_DATASETS,
+    "dnoa": DNOA_DATASETS,
+    "network_stats": NETWORK_STATS_DATASETS,
+    "powerflow": POWERFLOW_DATASETS,
+    "flexibility": FLEXIBILITY_DATASETS,
+    "curtailment": CURTAILMENT_DATASETS,
+    "ders": DER_DATASETS,
+    "gis": GEO_DATASETS,
+    "equipment": EQUIPMENT_DATASETS,
+    "connections": CONNECTIONS_DATASETS,
+    "operations": OPERATIONS_DATASETS,
+    "sensitivity": SENSITIVITY_DATASETS,
+    "smart": SMART_LCT_DATASETS,
+    "profiles": PROFILES_DATASETS,
+    "appendix_g": APPENDIX_G_DATASETS,
+    "reference": REFERENCE_DATASETS,
+}


### PR DESCRIPTION
## What

Implementing `fetch` and `list` parsers to the CLI tooling. 

### Fetch

`fetch` will provide a brief summary, however when specified with an `--output` argument, can export to that appropriate file format.
- fetch
  - dataset_id: Provides a summary of the dataset when not provided with an output argument
    - output: Exports the dataset to the current working directory to the provided format

In the future this could accept a filepath argument but out of scope for now :^)

### List
`list` will allow the user to query all datasets and domains, as well as to find all datasets within a domain with a `--domain` argument.
- list
  - datasets: list all datasets
    - domain: filter by domain
  - domains: list all domains

## Why

I thought it'd be neat to be able to directly query the CLI of what datasets are available, as well as being able to fetch these datasets. As the implementation for the orchestrators are already there, it should be a relatively simple feature.

Additionally, there's room to grow the functionality in the CLI and I thought this would be a good baseline to start from (at least to provide a very succinct interface to interact with the datasets without having to introduce another dependency to a project). 

Thought process here is to easily discover and download datasets directly from CLI, no external dependencies.

### Note

~~This PR is a WIP and I am going through the processes of understanding the CI/CD inplace+contribution guidelines.~~