### PR TITLE
feat: apply ukpn- prefix to renamed ODP dataset IDs #minor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Record.geometry` property — normalised GeoJSON geometry accessor that resolves from whichever raw field the ODP uses (`geo_shape`, `spatial_coordinates`, `geo_point_2d`, `geo_point`, `geopoint`) and converts `{"lat", "lon"}` dicts to standard GeoJSON `Point`
 - `dimensions` parameter on `GISOrchestrator.export_geojson()` — choose `"2d"` (strip Z), `"3d"` (ensure Z), or `"raw"` (default, pass-through) to normalise coordinate dimensionality
 
+### Changed
+- Applied `ukpn-` prefix to renamed ODP dataset IDs: `ltds-table-3a-load-data-observed` → `ukpn-ltds-table-3a-load-data-observed` and `dfes-network-headroom-report` → `ukpn-dfes-network-headroom-report`. Updated the dataset registry, field schema snapshot, and the `02-fetching-data` tutorial accordingly
+
 ### Fixed
 - NaN / Infinity values in record fields are now sanitised to `None` on parse — ODP occasionally returns `float('nan')` which is invalid JSON and breaks all downstream consumers
 - GeoJSON `Feature` wrappers in geometry fields (e.g. `geo_shape` on poles datasets) are automatically unwrapped to bare geometry dicts

--- a/src/ukpyn/dataset_registry.py
+++ b/src/ukpyn/dataset_registry.py
@@ -22,9 +22,9 @@ LTDS_DATASETS: dict[str, str] = {
     "table_2b": "ltds-table-2b-transformer-data-3w",
     "transformer_3w": "ltds-table-2b-transformer-data-3w",
     # Table 3a - Observed peak demand at primary substations
-    "table_3a": "ltds-table-3a-load-data-observed",
-    "observed_demand": "ltds-table-3a-load-data-observed",
-    "observed_peak_demand": "ltds-table-3a-load-data-observed",  # Legacy alias
+    "table_3a": "ukpn-ltds-table-3a-load-data-observed",
+    "observed_demand": "ukpn-ltds-table-3a-load-data-observed",
+    "observed_peak_demand": "ukpn-ltds-table-3a-load-data-observed",  # Legacy alias
     # Table 3a Transposed - Same data, pivoted format
     "table_3a_transposed": "ltds-table-3a-load-data-observed-transposed",
     # Table 3b - True (firm) demand forecasts
@@ -65,8 +65,8 @@ LTDS_DATASETS: dict[str, str] = {
 # =============================================================================
 DFES_DATASETS: dict[str, str] = {
     # Network headroom report - capacity availability by scenario
-    "headroom": "dfes-network-headroom-report",
-    "headroom_report": "dfes-network-headroom-report",
+    "headroom": "ukpn-dfes-network-headroom-report",
+    "headroom_report": "ukpn-dfes-network-headroom-report",
     # Peak demand scenarios by local authority
     "peak_demand_scenarios": "ukpn-dfes-peak-demand-scenarios",
     # DFES data aggregated by local authority

--- a/src/ukpyn/field_schemas.json
+++ b/src/ukpyn/field_schemas.json
@@ -1,5 +1,5 @@
 {
-  "dfes-network-headroom-report": [
+  "ukpn-dfes-network-headroom-report": [
     "bulksupplypoint",
     "category",
     "demand_rag",
@@ -143,7 +143,7 @@
     "zero_sequence_impedance_x_hv_lv2_percent",
     "zero_sequence_impedance_x_lv1_lv2_percent"
   ],
-  "ltds-table-3a-load-data-observed": [
+  "ukpn-ltds-table-3a-load-data-observed": [
     "firm_capacity_mw",
     "forecast_m_d_mw_25_26",
     "forecast_m_d_mw_26_27",

--- a/tests/orchestrators/test_ltds.py
+++ b/tests/orchestrators/test_ltds.py
@@ -53,8 +53,7 @@ class TestLTDSDatasetsMapping:
         assert LTDS_DATASETS["capacity_heatmap"] == "ukpn-capacity-heatmap"
         assert LTDS_DATASETS["heatmap"] == LTDS_DATASETS["capacity_heatmap"]
         assert (
-            LTDS_DATASETS["ltds_capacity_heatmap"]
-            == LTDS_DATASETS["capacity_heatmap"]
+            LTDS_DATASETS["ltds_capacity_heatmap"] == LTDS_DATASETS["capacity_heatmap"]
         )
 
     def test_orchestrator_uses_ltds_datasets(self) -> None:

--- a/tutorials/02-fetching-data.ipynb
+++ b/tutorials/02-fetching-data.ipynb
@@ -529,7 +529,7 @@
    "outputs": [],
    "source": [
     "# Discover facet fields and their values for a dataset\n",
-    "FACET_DATASET_ID = \"ltds-table-3a-load-data-observed\"\n",
+    "FACET_DATASET_ID = \"ukpn-ltds-table-3a-load-data-observed\"\n",
     "\n",
     "async with UKPNClient() as client:\n",
     "    facets = await client.get_facets(FACET_DATASET_ID)\n",


### PR DESCRIPTION
## Summary

Renamed datasets in the ODP now carry a `ukpn-` prefix. This PR updates the dataset registry, field schema snapshot, and the `02-fetching-data` tutorial accordingly.

| Old ID | New ID |
|---|---|
| `ltds-table-3a-load-data-observed` | `ukpn-ltds-table-3a-load-data-observed` |
| `dfes-network-headroom-report` | `ukpn-dfes-network-headroom-report` |

## Changes

- **`src/ukpyn/dataset_registry.py`** — updated `table_3a` / `observed_demand` / `observed_peak_demand` and `headroom` / `headroom_report` mappings
- **`src/ukpyn/field_schemas.json`** — renamed the two schema snapshot keys
- **`tutorials/02-fetching-data.ipynb`** — updated `FACET_DATASET_ID`
- **`CHANGELOG.md`** — documented the rename under `[Unreleased]`

## Notes

- The remaining 5 renamed ODP tables (`parliamentary_constituency_boundaries_ukpn`, `defra-national-parks`, `top-30-use-cases`, `project-enable`, `areas-of-outstanding-natural-beauty-england`) are **not** referenced anywhere in this repo, so no changes were needed for them.
- The closely-named `ltds-table-3a-load-data-observed-transposed` was intentionally left unchanged (not in the rename list).
- **Versioning:** `pyproject.toml` is **not** bumped in this PR — the `version-tag` CI workflow owns that. The `#minor` keyword is included so merging to `main` bumps `1.1.5` → `1.2.0` and tags `v1.2.0`. ⚠️ Ensure the squash/merge commit message retains `#minor`.