### PR TITLE
ci: auto-promote CHANGELOG [Unreleased] on release bump

### DIFF
--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -87,6 +87,25 @@ jobs:
           )
           pyproject.write_text(new_text, encoding="utf-8")
 
+          # Promote the CHANGELOG [Unreleased] section to the new version.
+          # Leaves a fresh, empty [Unreleased] heading for future notes.
+          from datetime import date, timezone, datetime
+
+          changelog = Path("CHANGELOG.md")
+          if changelog.exists():
+              cl_text = changelog.read_text(encoding="utf-8")
+              today = datetime.now(timezone.utc).date().isoformat()
+              already_released = re.search(
+                  rf'^##\s*\[{re.escape(new_version)}\]', cl_text, re.MULTILINE
+              )
+              if not already_released and "## [Unreleased]" in cl_text:
+                  cl_text = cl_text.replace(
+                      "## [Unreleased]",
+                      f"## [Unreleased]\n\n## [{new_version}] - {today}",
+                      1,
+                  )
+                  changelog.write_text(cl_text, encoding="utf-8")
+
           out_path = Path(os.environ["GITHUB_OUTPUT"])
           with out_path.open("a", encoding="utf-8") as fh:
               fh.write(f"new_version={new_version}\n")
@@ -109,7 +128,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git add pyproject.toml
+          git add pyproject.toml CHANGELOG.md
           git commit -m "chore(release): v${{ steps.version.outputs.new_version }} [skip ci]"
           git pull --rebase origin main
           git push origin HEAD:main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `version-tag` release workflow now automatically promotes the CHANGELOG `[Unreleased]` section to a dated version heading on each release bump, keeping the changelog in sync with the version published to PyPI
+
+## [1.2.0] - 2026-06-25
+
 ### Added
 - `Record.geometry` property — normalised GeoJSON geometry accessor that resolves from whichever raw field the ODP uses (`geo_shape`, `spatial_coordinates`, `geo_point_2d`, `geo_point`, `geopoint`) and converts `{"lat", "lon"}` dicts to standard GeoJSON `Point`
 - `dimensions` parameter on `GISOrchestrator.export_geojson()` — choose `"2d"` (strip Z), `"3d"` (ensure Z), or `"raw"` (default, pass-through) to normalise coordinate dimensionality


### PR DESCRIPTION
## Summary

Automates CHANGELOG maintenance so the changelog never drifts from the version published to PyPI again.

Previously the `version-tag` workflow bumped `pyproject.toml` and tagged a release, but **nothing ever touched `CHANGELOG.md`** — so the `[Unreleased]` section was never promoted to a dated version heading. v1.2.0 shipped with its notes still sitting under `[Unreleased]`.

## Changes

### `.github/workflows/version-tag.yml`
- The version-calculation step now also rewrites `CHANGELOG.md`: it promotes `## [Unreleased]` to `## [Unreleased]` + `## [X.Y.Z] - <UTC date>`, leaving a fresh empty `[Unreleased]` for future notes.
- Guards against double-promotion (skips if `## [X.Y.Z]` already exists).
- The release commit now stages `CHANGELOG.md` alongside `pyproject.toml`.

### `CHANGELOG.md`
- Retroactively promotes the already-shipped **v1.2.0** content (geometry accessor, `dimensions` param, `ukpn-` dataset prefixes, NaN/Feature fixes) out of `[Unreleased]` into `## [1.2.0] - 2026-06-25`.
- Documents the new workflow automation under a fresh `[Unreleased]`.

## Release behaviour

This PR is intended as a **patch bump** (no `#minor`/`#major` keyword), so on merge:
1. `version-tag` bumps `1.2.0` → **`1.2.1`** and tags `v1.2.1`.
2. The new automation promotes the `[Unreleased]` workflow note → `## [1.2.1] - <date>` — i.e. the feature validates itself on first run.

⚠️ Keep the squash/merge commit message free of `#minor`/`#major` so it stays a patch.